### PR TITLE
fixed Rank calculation in special cases

### DIFF
--- a/src/Rank.php
+++ b/src/Rank.php
@@ -54,9 +54,6 @@ class Rank
                 continue;
             }
 
-//            var_dump($midChar);
-//            die;
-
             $rank .= $midChar;
             break;
         }
@@ -71,6 +68,10 @@ class Rank
 
     private function mid(string $prev, string $next)
     {
+        if (ord($prev) > ord($next)) {
+            return ($prev);
+        }
+
         return chr((ord($prev) + ord($next)) / 2);
     }
 

--- a/tests/RankTest.php
+++ b/tests/RankTest.php
@@ -43,4 +43,10 @@ class RankTest extends TestCase
         $this->assertSame('azU', $rank);
     }
 
+    public function testSuccessNewDigitMidValueSpecialCase()
+    {
+        $rank = (new Rank('amz', 'ana'))->get();
+        $this->assertSame('amzU', $rank);
+    }
+
 }


### PR DESCRIPTION
Resolves #2 

It's not the optimal solution, because the patch always add a new char to have more 'precision' in the generated rank, but at least the sorted result is correct.

I should like to have something similar:
```
    public function testSuccessNewDigitMidValueSpecial2()
    {
        $rank = (new Rank('amu', 'anb'))->get();
        self::markTestSkipped();
        $this->assertSame('amz', $rank);
    }
```
and not `amuU` 




cc @ocramius